### PR TITLE
TimeHelper

### DIFF
--- a/app/actions/__init__.py
+++ b/app/actions/__init__.py
@@ -7,6 +7,7 @@ from app import db_models, db_schemas, logger
 import app.object_models as object_models
 import app.utils.sslyze.scanner as sslyze_scanner
 import app.utils.sslyze.parse_result as sslyze_parse_result
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 from . import sensor_collector
 
@@ -99,9 +100,9 @@ def get_last_scan_and_result(target_id: int, user_id: int) -> Optional[
 
 
 def get_scan_history(user_id: int, x_days: int = 30):  # -> Optional[Tuple[db_models.LastScan, db_models.ScanResults]]:
-    today = datetime.datetime.now()
+    today = time_source.time()
     start = today - datetime.timedelta(days=x_days)
-    start_timestamp = db_models.datetime_to_timestamp(start)
+    start_timestamp = datetime_to_timestamp(start)
 
     res = db_models.db.session \
         .query(db_models.ScanOrder, db_models.Target, db_models.ScanResultsHistory, db_models.ScanResultsSimplified) \

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -12,6 +12,7 @@ from typing import Optional
 import app
 import app.utils.db.basic as db_utils
 from sslyze.ssl_settings import TlsWrappedProtocolEnum
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 from config import SchedulerConfig
 
@@ -34,16 +35,6 @@ class NumericTimestamp(TypeDecorator):
     #
     # def process_result_value(self, value, dialect):
     #     return datetime.datetime.utcfromtimestamp(value)  # todo: timezone?
-
-
-def datetime_to_timestamp(x: datetime.datetime) -> int:
-    if x is None:
-        return None
-    return int(x.timestamp())
-
-
-def timestamp_to_datetime(x: int) -> datetime.datetime:
-    return datetime.datetime.utcfromtimestamp(x)
 
 
 class UniqueModel(object):
@@ -209,7 +200,7 @@ class LastScan(Base, UniqueModel):  # this might not have to be in DB, it might 
     def create_if_not_existent(cls, target_id):
         try:
             rand_time_offset = random.randrange(0, SchedulerConfig.max_first_scan_delay)
-            enqueue_time = datetime.datetime.now()\
+            enqueue_time = time_source.time()\
                            - datetime.timedelta(seconds=SchedulerConfig.enqueue_min_time) \
                            + datetime.timedelta(seconds=rand_time_offset)
 
@@ -733,7 +724,7 @@ class ScanResultsHistory(Base, UniqueModel):
 
     id = db.Column(db.Integer, primary_key=True)
 
-    timestamp = db.Column(NumericTimestamp, default=datetime_to_timestamp(datetime.datetime.now()))
+    timestamp = db.Column(NumericTimestamp, default=time_source.timestamp())
 
     target_id = db.Column(db.Integer, db.ForeignKey('targets.id'), nullable=False)
     target = db.relationship("Target")
@@ -749,7 +740,7 @@ class SentNotificationsLog(Base, UniqueModel):
 
     id = db.Column(db.Integer, primary_key=True)
 
-    timestamp = db.Column(NumericTimestamp, default=datetime_to_timestamp(datetime.datetime.now()))
+    timestamp = db.Column(NumericTimestamp, default=time_source.timestamp())
 
     sent_notification_id = db.Column(db.String, nullable=False)
     channel = db.Column(db.String, nullable=False)
@@ -833,7 +824,7 @@ class TmpRandomCodes(Base, UniqueModel):
     __table_args__ = (db.UniqueConstraint(*__uniqueColumns__, name=f'_uq_{__tablename__}'),)
 
     id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(NumericTimestamp, default=datetime_to_timestamp(datetime.datetime.now()))
+    timestamp = db.Column(NumericTimestamp, default=time_source.timestamp())
     expires = db.Column(NumericTimestamp)
 
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'))

--- a/app/utils/notifications/general.py
+++ b/app/utils/notifications/general.py
@@ -9,6 +9,7 @@ import app.utils.db.basic as db_utils
 from app.utils.notifications.user_preferences import get_effective_active_notification_settings
 from app.utils.notifications.connection_types import Notification
 from app.utils.notifications.event_type_expiration import NotificationTypeExpiration
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 # def get_res_old_and_new(changed_targets):
 #     # todo: this might not work, it's not finished.
@@ -21,7 +22,7 @@ from app.utils.notifications.event_type_expiration import NotificationTypeExpira
 #         .filter(db_models.ScanOrder.target_id.in_(changed_targets)) \
 #         .all()
 #
-#     minimum_wait_time = db_models.datetime_to_timestamp(datetime.datetime.now() - datetime.timedelta(minutes=5))
+#     minimum_wait_time = datetime_to_timestamp(time_source.time() - datetime.timedelta(minutes=5))
 #
 #     res_old = db_models.db.session \
 #         .query(db_models.ScanOrder, db_models.Target, db_models.ScanResults) \

--- a/app/utils/randomCodes.py
+++ b/app/utils/randomCodes.py
@@ -5,6 +5,7 @@ import random
 from typing import Union, Tuple
 
 import app.db_models as db_models
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 
 class ActivityType(Enum):
@@ -24,7 +25,7 @@ def create_and_save_random_code(activity: ActivityType, user_id: int, expire_in_
     res = db_models.TmpRandomCodes()
     res.user_id = user_id
     res.activity = activity.name
-    res.expires = db_models.datetime_to_timestamp(datetime.datetime.now() + datetime.timedelta(minutes=expire_in_n_minutes))
+    res.expires = datetime_to_timestamp(time_source.time() + datetime.timedelta(minutes=expire_in_n_minutes))
     res.code = gen_random_code()
     res.params = params
     db_models.db.session.add(res)
@@ -38,7 +39,7 @@ def validate_code(db_code: str, activity: ActivityType, user_id=None)\
         .query(db_models.TmpRandomCodes) \
         .filter(db_models.TmpRandomCodes.code == db_code) \
         .filter(db_models.TmpRandomCodes.activity == activity.name) \
-        .filter(db_models.TmpRandomCodes.expires >= db_models.datetime_to_timestamp(datetime.datetime.now()))
+        .filter(db_models.TmpRandomCodes.expires >= time_source.timestamp())
 
     if user_id:
         query = query.\

--- a/app/utils/sslyze/parse_result.py
+++ b/app/utils/sslyze/parse_result.py
@@ -20,6 +20,7 @@ import app.utils.certificate as certificate
 import app.utils.db.basic as db_utils
 import app.utils.db.advanced as db_utils_advanced
 import app.utils.files as files
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 still_to_parse_test = True
 
@@ -422,13 +423,12 @@ def update_references_to_scan_result_single_target(target_id: int, scanresult_id
     db_utils_advanced.generic_get_create_edit_from_data(db_schemas.ScanResultsHistorySchema,
                                                         {'target_id': target_id,
                                                          'scanresult_id': scanresult_id,
-                                                         'timestamp': db_models.datetime_to_timestamp(
-                                                             datetime.datetime.now())
+                                                         'timestamp': time_source.timestamp(),
                                                          })
 
     # ls = db_utils_advanced.generic_get_create_edit_from_data(db_schemas.LastScanSchema,
     #                                                          {'target_id': target_id,
-    #                                                           'last_scanned': db_models.datetime_to_timestamp(datetime.datetime.now()),
+    #                                                           'last_scanned': time_source.timestamp(),
     #                                                           'scanresult_id': scanresult_id,
     #                                                           # 'last_enqueued': # previous value
     #                                                           })
@@ -439,6 +439,6 @@ def update_references_to_scan_result_single_target(target_id: int, scanresult_id
     if ls is None:
         logger.error(f"Scan result for a target which doesn't have Last Scan record. {target_id}")
         return
-    ls.last_scanned = db_models.datetime_to_timestamp(datetime.datetime.now())
+    ls.last_scanned = time_source.timestamp()
     ls.result_id = scanresult_id
     db_utils_advanced.generic_get_create_edit_from_transient(db_schemas.LastScanSchema, ls)

--- a/app/utils/sslyze/simplify_result.py
+++ b/app/utils/sslyze/simplify_result.py
@@ -4,6 +4,7 @@ import app.db_models as db_models
 import app.utils.db.basic as db_utils
 from loguru import logger
 import app.utils.sslyze.grade_scan_result as grade_scan_result
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 
 def count_after_split_of_param_if_not_none(x: Optional[object], param_name: str) -> Optional[int]:
@@ -46,8 +47,8 @@ def sslyze_result_simplify(scan_result: db_models.ScanResults) -> db_models.Scan
         chain_for_dates = verified_chain_list if verified_chain_list else received_chain_list
 
         if chain_for_dates:
-            simple.notAfter = db_models.datetime_to_timestamp(chain_for_dates.not_after())
-            simple.notBefore = db_models.datetime_to_timestamp(chain_for_dates.not_before())
+            simple.notAfter = datetime_to_timestamp(chain_for_dates.not_after())
+            simple.notBefore = datetime_to_timestamp(chain_for_dates.not_before())
 
     simple.sslv2_working_ciphers_count = count_after_split_of_param_if_not_none(scan_result.sslv2, "accepted_cipher_list")
     simple.sslv3_working_ciphers_count = count_after_split_of_param_if_not_none(scan_result.sslv3, "accepted_cipher_list")

--- a/app/utils/time_helper.py
+++ b/app/utils/time_helper.py
@@ -46,7 +46,7 @@ class TimeHelper:
         return datetime.now()
 
     def timestamp(self):
-        datetime_to_timestamp(self.time())
+        return datetime_to_timestamp(self.time())
 
 
 time_source = TimeHelper()

--- a/app/utils/time_helper.py
+++ b/app/utils/time_helper.py
@@ -40,12 +40,12 @@ class TimeHelper:
     def offset_time(self, td: timedelta):
         self.__mocked_time += td
 
-    def time(self):
+    def time(self) -> datetime:
         if self.mock():
             return self.__mocked_time
         return datetime.now()
 
-    def timestamp(self):
+    def timestamp(self) -> int:
         return datetime_to_timestamp(self.time())
 
 

--- a/app/utils/time_helper.py
+++ b/app/utils/time_helper.py
@@ -1,0 +1,53 @@
+from typing import Optional
+from loguru import logger
+from datetime import datetime, timedelta
+
+
+def datetime_to_timestamp(x: datetime) -> Optional[int]:
+    if x is None:
+        return None
+    return int(x.timestamp())
+
+
+def timestamp_to_datetime(x: int) -> datetime:
+    return datetime.utcfromtimestamp(x)
+
+
+class TimeHelper:
+    """
+    Instance of this class should serve as a single source of truth for time in the whole application.
+    It allows dynamic mocking of time, which is especially useful in tests of scheduler functions.
+    """
+
+    def __init__(self):
+        self.__mock: bool = False
+        self.__mocked_time: datetime = datetime.fromtimestamp(0)
+
+    def mock(self, status: Optional[bool] = None) -> bool:
+        if status is not None and self.__mock != status:
+            # todo: consider adding logger.warning for situation when time mocking is enabled in production
+            self.__mock = status
+            logger.debug(f"Time mocking {'enabled' if status else 'disabled'}")
+
+        return self.__mock
+
+    def set_now(self):
+        self.set_time(datetime.now())
+
+    def set_time(self, mock_time: datetime):
+        self.__mocked_time = mock_time
+
+    def offset_time(self, td: timedelta):
+        self.__mocked_time += td
+
+    def time(self):
+        if self.mock():
+            return self.__mocked_time
+        return datetime.now()
+
+    def timestamp(self):
+        datetime_to_timestamp(self.time())
+
+
+time_source = TimeHelper()
+

--- a/app/views/debug/__init__.py
+++ b/app/views/debug/__init__.py
@@ -3,3 +3,4 @@ from flask import Blueprint
 bp = Blueprint('apiDebug', __name__)
 
 from . import misc
+from . import tests

--- a/app/views/debug/misc.py
+++ b/app/views/debug/misc.py
@@ -31,6 +31,7 @@ import app.utils.extract_test as extract_test
 import app.utils.authentication_utils as authentication_utils
 import app.utils.normalize_jsons as normalize_jsons
 import app.object_models as object_models
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 
 @bp.route('/sslyze_get_direct_scan/<string:domain>')
@@ -134,7 +135,7 @@ def scenario1():
 
         db_models.ScanOrder.from_kwargs({"target_id": 1, "user_id": 1, "periodicity": 60})
 
-        # date_offseted = datetime.datetime.now() - datetime.timedelta(days=10)
+        # date_offseted = time_source.time() - datetime.timedelta(days=10)
         # db.session.query(db_models.LastScan) \
         #     .update({db_models.LastScan.last_enqueued: date_offseted}, synchronize_session='fetch')
 

--- a/app/views/debug/tests.py
+++ b/app/views/debug/tests.py
@@ -1,0 +1,8 @@
+
+from . import bp
+
+from app.utils.time_helper import time_source
+
+@bp.route('/current_timestamp', methods=['GET'])
+def current_timestamp():
+    return str(time_source.timestamp()), 200

--- a/app/views/v1/misc.py
+++ b/app/views/v1/misc.py
@@ -1,5 +1,4 @@
 import copy
-import datetime
 import json
 import random
 from typing import List
@@ -30,6 +29,7 @@ import app.actions as actions
 import app.actions.sensor_collector as sensor_collector
 import app.views.v1.notification_settings as slack_url_to_oauth
 import app.utils.randomCodes as randomCodes
+from app.utils.time_helper import time_source, datetime_to_timestamp, timestamp_to_datetime
 from config import SlackConfig
 
 
@@ -216,7 +216,7 @@ def api_get_user_targets():
 
                 if scan_result_simplified:
                     if isinstance(single_res.ScanResultsSimplified.notAfter, int):
-                        obj["expires"] = str(datetime.datetime.fromtimestamp(single_res.ScanResultsSimplified.notAfter))
+                        obj["expires"] = str(timestamp_to_datetime(single_res.ScanResultsSimplified.notAfter))
                     obj["grade"] = single_res.ScanResultsSimplified.grade
                     obj["grade_reasons"] = single_res.ScanResultsSimplified.grade_reasons
                     continue
@@ -254,7 +254,7 @@ def api_get_result_for_target(target_id):
     scan_result: db_models.ScanResults
 
     last_scanned = last_scan.last_scanned
-    last_scanned_datetime = db_models.timestamp_to_datetime(last_scanned)
+    last_scanned_datetime = timestamp_to_datetime(last_scanned)
 
     scan_result_str = db_schemas.ScanResultsSchema().dumps(scan_result)
 
@@ -273,7 +273,7 @@ def api_get_basic_cert_info_for_target(target_id):
     if scan_result is None:
         return "Target either doesn't exist or the current user doesn't have permission to view it.", 401
 
-    last_scanned_datetime = db_models.timestamp_to_datetime(last_scan.last_scanned)
+    last_scanned_datetime = timestamp_to_datetime(last_scan.last_scanned)
     cert_info = scan_result.certificate_information
     verified_chain = cert_info.verified_certificate_chain_list
     certificates_in_chain: List[db_models.Certificate] = db_models.Certificate.select_from_list(verified_chain.chain)

--- a/app/views/v1/notification_settings.py
+++ b/app/views/v1/notification_settings.py
@@ -20,6 +20,7 @@ import app.utils.randomCodes as randomCodes
 import app.db_models as db_models
 import app.utils.authentication_utils as authentication_utils
 import app.actions as actions
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 
 @bp.route("/slack/begin_auth", methods=["GET"])
@@ -149,7 +150,7 @@ def api_resend_validation_email():
         .filter(db_models.TmpRandomCodes.user_id == user_id) \
         .filter(db_models.TmpRandomCodes.activity == randomCodes.ActivityType.MAIL_VALIDATION.name) \
         .filter(db_models.TmpRandomCodes.timestamp >
-                db_models.datetime_to_timestamp(datetime.datetime.now() - datetime.timedelta(minutes=1))) \
+                datetime_to_timestamp(time_source.time() - datetime.timedelta(minutes=1))) \
         .all()
 
     if res is not None:

--- a/app/views/v1/sensor_collector.py
+++ b/app/views/v1/sensor_collector.py
@@ -20,6 +20,7 @@ import app.scan_scheduler as scan_scheduler
 import app.db_models as db_models
 import app.actions as actions
 import app.actions.sensor_collector as sensor_collector
+from app.utils.time_helper import time_source, datetime_to_timestamp
 
 
 @bp.route('/get_next_targets_batch')
@@ -110,8 +111,8 @@ def api_send_notifications_for_period(sensor_key=None):
             f'Request to send notifications: unauthorized: key: {sensor_key}, IP: {request.remote_addr}')
         return 'Access only allowed with valid SENSOR_COLLECTOR_KEY or from localhost', 401
 
-    timestamp_start_from = db_models.datetime_to_timestamp(
-        datetime.datetime.now() -
+    timestamp_start_from = datetime_to_timestamp(
+        time_source.time() -
         datetime.timedelta(minutes=NotificationsConfig.how_long_to_retry_sending_notifications)
     )
 

--- a/tests/time_helper.py
+++ b/tests/time_helper.py
@@ -1,0 +1,51 @@
+import pytest
+from datetime import datetime, timedelta
+from app.utils.time_helper import time_source
+
+class TestSuiteTimeHelper:
+    ALLOWED_TIME_DIFF = timedelta(seconds=1)
+
+    def test_current_time(self):
+        test_time = time_source.time()
+        assert abs(datetime.now() - test_time) < self.ALLOWED_TIME_DIFF
+        assert abs(datetime.fromtimestamp(0) - test_time) > self.ALLOWED_TIME_DIFF
+
+    def test_mocked_time(self):
+        mock_time = datetime.fromtimestamp(42)
+        time_source.set_time(mock_time)
+
+        assert time_source.mock() == False
+        assert abs(datetime.now() - time_source.time()) < self.ALLOWED_TIME_DIFF
+
+        assert time_source.mock(True)
+        assert mock_time == time_source.time()
+
+        assert time_source.mock(False) == False
+        assert abs(datetime.now() - time_source.time()) < self.ALLOWED_TIME_DIFF
+
+    def test_set_now(self):
+        time_source.mock(True)
+        time_source.set_now()
+        assert abs(datetime.now() - time_source.time()) < self.ALLOWED_TIME_DIFF
+
+    def test_offset(self):
+        time_source.mock(True)
+        mock_time = datetime.fromtimestamp(42)
+        time_source.set_time(mock_time)
+
+        td = timedelta(seconds=28)
+
+        assert abs(mock_time - time_source.time()) < self.ALLOWED_TIME_DIFF
+
+        time_source.offset_time(td)
+        assert abs(mock_time + td - time_source.time()) < self.ALLOWED_TIME_DIFF
+
+        time_source.offset_time(-td)
+        assert abs(mock_time - time_source.time()) < self.ALLOWED_TIME_DIFF
+
+    def test_timestamp(self):
+        time_source.mock(True)
+        for i in range(5):
+            mock_time = datetime.fromtimestamp(i)
+            time_source.set_time(mock_time)
+            assert time_source.timestamp() == i


### PR DESCRIPTION
Instance of this class should serve as a single source of truth for time in the whole application.
It allows dynamic mocking of time, which is especially useful in tests of scheduler functions.

- [x] implement the class
- [x] add direct tests
- [x] add tests through API
- [x] remove functions `datetime_to_timestamp` and `timestamp_to_datetime` from db_models.py
- [x] change all time calls in the programs to point to this helper