### PR TITLE
Draft: Fix the losing of history on unchanging scan results

### DIFF
--- a/app/db_models.py
+++ b/app/db_models.py
@@ -720,7 +720,7 @@ class ScanResults(Base, UniqueModel):
 
 class ScanResultsHistory(Base, UniqueModel):
     __tablename__ = 'scanresultshistory'
-    __uniqueColumns__ = ['target_id', 'scanresult_id']
+    __uniqueColumns__ = ['target_id', 'scanresult_id', 'timestamp']
     __table_args__ = (db.UniqueConstraint(*__uniqueColumns__, name=f'_uq_{__tablename__}'),)
 
     id = db.Column(db.Integer, primary_key=True)

--- a/tests/scan_scheduler_test.py
+++ b/tests/scan_scheduler_test.py
@@ -8,6 +8,7 @@ from config import SchedulerConfig
 
 from tests.auth_test import login, register
 
+
 @pytest.mark.usefixtures('client_class')
 class TestSuiteScanScheduler:
     SMALL_OFFSET = timedelta(seconds=10)  # seconds
@@ -17,9 +18,10 @@ class TestSuiteScanScheduler:
     def __do_authentication(self):
         assert self.client.get(url_for("apiDebug.debugSetAccessCookie")).status_code == 200
 
-    def __target_add_data(self, hostname:str ="example.com", ip: Optional[str]=None):
+    @staticmethod
+    def __target_add_data(hostname: str = "example.com", ip: Optional[str] = None, port: Optional[int] = None):
         return {
-            "target": {"id": None, "hostname": hostname, "port": None, "ip_address": ip, "protocol": "HTTPS"},
+            "target": {"id": None, "hostname": hostname, "port": port, "ip_address": ip, "protocol": "HTTPS"},
             "scanOrder": {"periodicity": 43200, "active": None}
          }
 

--- a/tests/sslyze_parse_test.py
+++ b/tests/sslyze_parse_test.py
@@ -11,9 +11,19 @@ from flask import url_for
 
 from app.utils.files import read_from_file
 import tests.conftest
+from tests.auth_test import login, register
+from tests.scan_scheduler_test import target_add_data
+import app.db_models as db_models
+
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 
 path_to_scan_results = f'{cur_dir}/data/scan_results'
+
+target_from_local_test_data_file = {
+    "hostname": "localhost",
+    # "ip_address": "127.0.0.1",
+    "port": 35051
+}
 
 
 @pytest.mark.usefixtures('client_class')
@@ -31,4 +41,35 @@ class TestSuiteSSLyzeParse:
                                 json=a
                                 )
         assert response.status_code == 200
+
+    @register
+    @login
+    def test_parse_two_related_scans(self):
+        assert self.client.get(url_for("apiDebug.debugSetAccessCookie")).status_code == 200
+
+        filename = "local_scan.json"
+        result_string = read_from_file(f'{path_to_scan_results}/{filename}')
+        a = {
+            "results_attached": True,
+            "results": [json.loads(result_string)]
+        }
+
+        response = self.client.put(
+            url_for("apiV1.api_target"),
+            json=target_add_data(
+                hostname=target_from_local_test_data_file["hostname"],
+                # ip=target_from_local_test_data_file["ip_address"],
+                port=target_from_local_test_data_file["port"]
+              )
+        )
+        assert response.status_code == 200
+
+        response = self.client.post(url_for("apiV1.api_sslyze_import_scan_results"), json=a)
+        assert response.status_code == 200
+
+        response = self.client.post(url_for("apiV1.api_sslyze_import_scan_results"), json=a)
+        assert response.status_code == 200
+
+        res = db_models.db.session.query(db_models.ScanResultsHistory).all()
+        assert len(res) == 2
 


### PR DESCRIPTION
If target_id and scanresult_id matches, new line should be created. Originally it appears that the existing record was rewritten and just the timestamp updated.

Todo:

- [x] write regression test
- [x] check if unique constraint get properly updated on an existing database

 Follow up:

- [ ] Add some request ID to logs, otherwise multiple simultaneous requests are indistinguishable 
- x Recover original history from logs? It's possible to reconstruct the missing data from logs, though it might not be neccesary.